### PR TITLE
pr fix 450

### DIFF
--- a/search/.env
+++ b/search/.env
@@ -1,0 +1,3 @@
+API_HOST=https://self-api.arguflow.ai/api
+PUBLIC_HOST=https://self-search.arguflow.ai
+PUBLIC_API_HOST=https://self-api.arguflow.ai/api


### PR DESCRIPTION
css not loading caused by env api_host var not picking up when the env file is not in the same directory as the yarn dev command. this file ensures the yarn dev command picks up env and nothing defined.

**the docker compose correctly puts the env.search and the search.env but that is not clear to those who are just running the yarn dev command**

multiple ways to solve -- make it more clear or just put sample file in there