### PR TITLE
cleanup: rename collections to themes in UI

### DIFF
--- a/search/src/components/BookmarkPopover.tsx
+++ b/search/src/components/BookmarkPopover.tsx
@@ -254,7 +254,7 @@ const BookmarkPopover = (props: BookmarkPopoverProps) => {
             >
               <Menu class=" flex w-full flex-col justify-end space-y-2 overflow-hidden rounded bg-white py-4 shadow-2xl dark:bg-shark-700">
                 <div class="mb-3 w-full px-4 text-center text-lg font-bold">
-                  Manage Collections For This Card
+                  Manage Themes For This Card
                 </div>
                 <MenuItem as="button" aria-label="Empty" />
                 <div class="max-w-screen mx-1 max-h-[20vh] transform justify-end space-y-2 overflow-y-auto rounded px-4 scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-600 scrollbar-track-rounded-md scrollbar-thumb-rounded-md dark:scrollbar-track-neutral-700 dark:scrollbar-thumb-neutral-400">
@@ -407,7 +407,7 @@ const BookmarkPopover = (props: BookmarkPopoverProps) => {
                       class="flex w-full items-center justify-center rounded-full border border-green-500 bg-transparent px-2 text-lg text-green-500"
                     >
                       <RiSystemAddFill class="h-5 w-5 fill-current" />
-                      <p> Create New Collection </p>
+                      <p> Create New Theme </p>
                     </MenuItem>
                   </div>
                 )}

--- a/search/src/components/CollectionPage.tsx
+++ b/search/src/components/CollectionPage.tsx
@@ -170,14 +170,14 @@ export const CollectionPage = (props: CollectionPageProps) => {
           });
         }
         if (response.status == 403) {
-          setError("You are not authorized to view this collection");
+          setError("You are not authorized to view this theme");
         }
         if (response.status == 404) {
-          setError("Collection not found, it never existed or was deleted");
+          setError("Theme not found, it never existed or was deleted");
         }
         if (response.status == 401) {
           setError(
-            "You must be logged in and authorized to view this collection",
+            "You must be logged in and authorized to view this theme",
           );
           setShowNeedLoginModal(true);
         }
@@ -212,7 +212,7 @@ export const CollectionPage = (props: CollectionPageProps) => {
           });
         }
         if (response.status == 403) {
-          setError("You are not authorized to view this collection");
+          setError("You are not authorized to view this theme");
         }
         if (response.status == 401) {
           setShowNeedLoginModal(true);
@@ -770,7 +770,7 @@ export const CollectionPage = (props: CollectionPageProps) => {
             >
               <div class="flex w-full flex-col items-center rounded-md p-2">
                 <div class="text-xl font-semibold">
-                  This collection is currently empty
+                  This theme is currently empty
                 </div>
               </div>
             </Show>
@@ -785,7 +785,7 @@ export const CollectionPage = (props: CollectionPageProps) => {
               <BiRegularXCircle class="mx-auto h-8 w-8 fill-current  !text-red-500" />
               <div class="mb-4 text-center text-xl font-bold">
                 Login or register to bookmark cards, vote, or view private
-                collections
+                themes
               </div>
               <div class="mx-auto flex w-fit flex-col space-y-3">
                 <a
@@ -809,7 +809,7 @@ export const CollectionPage = (props: CollectionPageProps) => {
           showConfirmModal={showConfirmCollectionDeleteModal}
           setShowConfirmModal={setShowConfirmCollectionmDeleteModal}
           onConfirm={onCollectionDelete}
-          message="Are you sure you want to delete this collection?"
+          message="Are you sure you want to delete this theme?"
         />
       </Show>
     </>

--- a/search/src/components/CommunityBookmarkPopover.tsx
+++ b/search/src/components/CommunityBookmarkPopover.tsx
@@ -35,7 +35,7 @@ const CommunityBookmarkPopover = (props: CommunityBookmarkPopoverProps) => {
             >
               <Menu class=" flex w-full flex-col justify-end space-y-2 overflow-hidden rounded bg-white py-4 shadow-xl dark:bg-shark-700">
                 <div class="mb-3 w-full px-4 text-center text-lg font-bold">
-                  Community Collections With This Card
+                  Community Themes With This Card
                 </div>
                 <MenuItem as="button" aria-label="Empty" />
                 <div class="scrollbar-track-rounded-md scrollbar-thumb-rounded-md max-w-screen mx-1 max-h-[20vh] transform justify-end space-y-2 overflow-y-auto rounded px-4 scrollbar-thin scrollbar-track-neutral-200 scrollbar-thumb-neutral-600 dark:scrollbar-track-neutral-700 dark:scrollbar-thumb-neutral-400">

--- a/search/src/components/UserCardDisplay.tsx
+++ b/search/src/components/UserCardDisplay.tsx
@@ -266,7 +266,7 @@ export const UserCardDisplay = (props: UserCardDisplayProps) => {
         showConfirmModal={showConfirmCollectionDeleteModal}
         setShowConfirmModal={setShowConfirmCollectionmDeleteModal}
         onConfirm={onCollectionDelete}
-        message={"Are you sure you want to delete this collection?"}
+        message={"Are you sure you want to delete this theme?"}
       />
     </>
   );


### PR DESCRIPTION
# Fixes issue:
- issue https://github.com/arguflow/arguflow/issues/560
- Rename collections to themes in UI for search

<br>

# Requirement to close
- [X] merged PR that changes collection to theme in search UI

<br>

# PR commit requirements for a bounty claim
- [X] 1 commit with a message of ```cleanup: rename collections to themes in UI```

<br>

# Files changed:
- BookmarkPopover.tsx (search/src/components/BookmarkPopover.tsx)
- CollectionPage.tsx (search/src/components/CollectionPage.tsx)
- CommunityBookmarkPopover.tsx (search/src/components/CommunityBookmarkPopover.tsx)
- UserCardDisplay.tsx (search/src/components/UserCardDisplay.tsx)

<br>

# Relevant Maintainers
- @skeptrunedev  


