### PR TITLE
styling: make the scroll bar in dark mode be dark colors

### DIFF
--- a/search/src/layouts/HomeLayout.astro
+++ b/search/src/layouts/HomeLayout.astro
@@ -100,7 +100,7 @@ try {
       src="https://perhaps.arguflow.com/js/script.js"></script>
   </head>
   <body
-    class="scrollbar-track-rounded-md scrollbar-thumb-rounded-md scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-700 dark:scrollbar-thumb-neutral-600"
+    class="scrollbar-thin scrollbar-thumb-rounded-md scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600"
   >
     <div
       class="flex min-h-screen flex-col bg-white dark:bg-shark-800 dark:text-white"

--- a/search/src/layouts/SearchLayout.astro
+++ b/search/src/layouts/SearchLayout.astro
@@ -113,7 +113,7 @@ try {
       src="https://perhaps.arguflow.com/js/script.js"></script>
   </head>
   <body
-    class="scrollbar-track-rounded-md scrollbar-thumb-rounded-md scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-700 dark:scrollbar-thumb-neutral-600"
+    class="scrollbar-thin scrollbar-thumb-rounded-md scrollbar-track-neutral-200 scrollbar-thumb-neutral-400 dark:scrollbar-track-neutral-800 dark:scrollbar-thumb-neutral-600"
   >
     <div
       class="flex min-h-screen flex-col bg-white dark:bg-shark-800 dark:text-white"


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
This PR updates the styling to ensure the scroll bar appears in dark colors when in dark mode.

Fixes: #544 

@skeptrunedev
Please review this PR for the styling related to scroll bar appearance. Your feedback is highly appreciated.