### PR TITLE
bugfix: when you are not auth'ed and get a 401 on the single card rec…

### DIFF
--- a/search/src/components/CollectionPage.tsx
+++ b/search/src/components/CollectionPage.tsx
@@ -357,6 +357,10 @@ export const CollectionPage = (props: CollectionPageProps) => {
           setRecommendedCards(new_recommendations);
         });
       }
+      if (response.status == 401) {
+        setShowNeedLoginModal(true);
+        setLoadingRecommendations(false);
+      }
     });
   };
 
@@ -769,8 +773,8 @@ export const CollectionPage = (props: CollectionPageProps) => {
             <div class="min-w-[250px] sm:min-w-[300px]">
               <BiRegularXCircle class="mx-auto h-8 w-8 fill-current  !text-red-500" />
               <div class="mb-4 text-center text-xl font-bold">
-                Login or register to bookmark cards, vote, or view private
-                themes
+                Login or register to bookmark cards, vote, get recommend cards
+                or view private themes
               </div>
               <div class="mx-auto flex w-fit flex-col space-y-3">
                 <a

--- a/search/src/components/SingleCardPage.tsx
+++ b/search/src/components/SingleCardPage.tsx
@@ -122,6 +122,10 @@ export const SingleCardPage = (props: SingleCardPageProps) => {
           setRecommendedCards(new_recommendations);
         });
       }
+      if (response.status == 401) {
+        setShowNeedLoginModal(true);
+        setLoadingRecommendations(false);
+      }
     });
   };
 
@@ -291,8 +295,8 @@ export const SingleCardPage = (props: SingleCardPageProps) => {
           <div class="min-w-[250px] sm:min-w-[300px]">
             <BiRegularXCircle class="mx-auto h-8 w-8 fill-current !text-red-500" />
             <div class="mb-4 text-center text-xl font-bold">
-              You must be signed in to vote, bookmark, or view this card it if
-              it's private
+              You must be signed in to vote, bookmark, get recommended cards, or
+              view this card it if it's private
             </div>
             <div class="mx-auto flex w-fit flex-col space-y-3">
               <a


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant

This PR implements the display of a modal form prompting users to sign in or register when encountering a 401 unauthorized error on card recommendations for a single card or collection.

Fixes: #588 

@skeptrunedev 
Please review this PR for the styling related to scroll bar appearance. Your feedback is highly appreciated.