### PR TITLE
bugfix: gen'ed openAPI spec now works with openapi-python-client

### DIFF
--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -397,7 +397,7 @@ impl ChunkCollection {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct SlimCollection {
     pub id: uuid::Uuid,
     pub name: String,
@@ -1126,7 +1126,7 @@ impl StripePlan {
 }
 
 #[derive(
-    Debug, Serialize, Deserialize, Selectable, Clone, Queryable, Insertable, ValidGrouping,
+    Debug, Serialize, Deserialize, Selectable, Clone, Queryable, Insertable, ValidGrouping, ToSchema,
 )]
 #[diesel(table_name = stripe_subscriptions)]
 pub struct StripeSubscription {

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -351,7 +351,7 @@ pub async fn create_chunk(
 
 #[utoipa::path(
     delete,
-    path = "/chunk/{chunk_id}}",
+    path = "/chunk/{chunk_id}",
     context_path = "/api",
     tag = "chunk",
     responses(

--- a/server/src/handlers/collection_handler.rs
+++ b/server/src/handlers/collection_handler.rs
@@ -139,7 +139,7 @@ pub async fn get_specific_user_chunk_collections(
 
 #[utoipa::path(
     get,
-    path = "/chunk_collection/{page_or_chunk_collection_id}",
+    path = "/chunk_collection/{page}",
     context_path = "/api",
     tag = "chunk_collection",
     responses(
@@ -147,7 +147,7 @@ pub async fn get_specific_user_chunk_collections(
         (status = 400, description = "Service error relating to getting the collections for the auth'ed user", body = [DefaultError]),
     ),
     params(
-        ("page_number" = u64, description = "The page of collections to fetch"),
+        ("page" = u64, description = "The page of collections to fetch"),
     ),
 )]
 pub async fn get_logged_in_user_chunk_collections(
@@ -289,7 +289,7 @@ pub struct AddChunkToCollectionData {
 
 #[utoipa::path(
     post,
-    path = "/chunk_collection/{page_or_chunk_collection_id}",
+    path = "/chunk_collection/{collection_id}",
     context_path = "/api",
     tag = "chunk_collection",
     request_body(content = AddChunkToCollectionData, description = "JSON request payload to add a chunk to a collection (bookmark it)", content_type = "application/json"),
@@ -298,7 +298,7 @@ pub struct AddChunkToCollectionData {
         (status = 400, description = "Service error relating to getting the collections that the chunk is in", body = [DefaultError]),
     ),
     params(
-        ("page_or_chunk_collection_id" = uuid::Uuid, description = "The id of the collection to add the chunk to"),
+        ("collection_id" = uuid, description = "Id of the collection to add the chunk to as a bookmark"),
     ),
 )]
 pub async fn add_bookmark(
@@ -485,7 +485,7 @@ pub struct RemoveBookmarkData {
 
 #[utoipa::path(
     delete,
-    path = "/chunk_collection/{page_or_chunk_collection_id}",
+    path = "/chunk_collection/{collection_id}",
     context_path = "/api",
     tag = "chunk_collection",
     request_body(content = RemoveBookmarkData, description = "JSON request payload to remove a chunk to a collection (un-bookmark it)", content_type = "application/json"),
@@ -494,7 +494,7 @@ pub struct RemoveBookmarkData {
         (status = 400, description = "Service error relating to removing the chunk from the collection", body = [DefaultError]),
     ),
     params(
-        ("page_or_chunk_collection_id" = uuid::Uuid, description = "The id of the collection to remove the bookmark'ed chunk from"),
+        ("collection_id" = uuid::Uuid, description = "Id of the collection to remove the bookmark'ed chunk from"),
     ),
 )]
 pub async fn delete_bookmark(

--- a/server/src/handlers/dataset_handler.rs
+++ b/server/src/handlers/dataset_handler.rs
@@ -173,7 +173,7 @@ pub async fn delete_dataset(
 
 #[utoipa::path(
     get,
-    path = "/dataset",
+    path = "/dataset/{dataset_id}",
     context_path = "/api",
     tag = "dataset",
     responses(

--- a/server/src/handlers/stripe_handler.rs
+++ b/server/src/handlers/stripe_handler.rs
@@ -170,8 +170,8 @@ pub struct GetDirectPaymentLinkData {
         (status = 400, description = "Service error relating to creating a URL for a stripe checkout page", body = [DefaultError]),
     ),
     params(
-        ("plan_id" = uuid, Path, description = "id of the plan you want to subscribe to"),
-        ("organization_id" = uuid, Path, description = "id of the organization you want to subscribe to the plan"),
+        ("plan_id" = uuid::Uuid, Path, description = "id of the plan you want to subscribe to"),
+        ("organization_id" = uuid::Uuid, Path, description = "id of the organization you want to subscribe to the plan"),
     ),
 )]
 pub async fn direct_to_payment_link(
@@ -268,8 +268,8 @@ pub struct UpdateSubscriptionData {
         (status = 400, description = "Service error relating to updating the subscription to the new plan", body = [DefaultError]),
     ),
     params(
-        ("subscription_id" = uuid, Path, description = "id of the subscription you want to update"),
-        ("plan_id" = uuid, Path, description = "id of the plan you want to subscribe to"),
+        ("subscription_id" = uuid::Uuid, Path, description = "id of the subscription you want to update"),
+        ("plan_id" = uuid::Uuid, Path, description = "id of the plan you want to subscribe to"),
     ),
 )]
 pub async fn update_subscription_plan(

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -179,6 +179,7 @@ pub async fn main() -> std::io::Result<()> {
                 data::models::ChunkMetadata,
                 data::models::ChunkMetadataWithFileData,
                 data::models::ChatMessageProxy,
+                data::models::SlimCollection,
                 data::models::UserDTOWithChunks,
                 data::models::File,
                 data::models::ChunkCollection,
@@ -186,6 +187,7 @@ pub async fn main() -> std::io::Result<()> {
                 data::models::FileDTO,
                 data::models::FileUploadCompletedNotificationWithName,
                 data::models::Organization,
+                data::models::OrganizationWithSubAndPlan,
                 data::models::Dataset,
                 data::models::DatasetAndUsage,
                 data::models::DatasetDTO,
@@ -194,6 +196,7 @@ pub async fn main() -> std::io::Result<()> {
                 data::models::DatasetAndOrgWithSubAndPlan,
                 data::models::ClientDatasetConfiguration,
                 data::models::StripePlan,
+                data::models::StripeSubscription,
                 errors::DefaultError,
             )
         ),


### PR DESCRIPTION
this makes it possible to generate a SDK for the API in python I think

attached the JSON gen of the spec at this stage
[openapi-v12.json](https://github.com/arguflow/arguflow/files/13996106/openapi-v12.json)
